### PR TITLE
Supporting webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-purchase",
   "version": "1.0.1",
   "description": "A NativeScript plugin for making in-app purchases",
-  "main": "purchase.js",
+  "main": "purchase",
   "nativescript": {
     "platforms": {
       "ios": "1.7.0",


### PR DESCRIPTION
In order to be a webpack-discoverable module, we need to remove the `.js` suffix in the package.json `main` attribute. This allows webpack to correctly look for `my-module.android.js` or `my-module.ios.js`.

Details here:
http://docs.nativescript.org/angular/tooling/bundling-with-webpack.html#referencing-platform-specific-modules-from-packagejson