### PR TITLE
Cannot read property 'getIntExtra' of null

### DIFF
--- a/purchase.android.ts
+++ b/purchase.android.ts
@@ -46,7 +46,7 @@ export function init(productIdentifiers: Array<string>): Promise<any> {
                 const dataSignature = intent && intent.getStringExtra("INAPP_DATA_SIGNATURE");
                 let tran: Transaction;
                 
-                if (typeof(responseCode)!=="undefined" && args.resultCode === android.app.Activity.RESULT_OK && responseCode === 0 && !types.isNullOrUndefined(purchaseData)) {
+                if (typeof(responseCode) !== "undefined" && args.resultCode === android.app.Activity.RESULT_OK && responseCode === 0 && !types.isNullOrUndefined(purchaseData)) {
                     const nativeValue = new org.json.JSONObject(purchaseData);
                     nativeValue.put("signature", dataSignature);
                     tran = new Transaction(nativeValue);

--- a/purchase.android.ts
+++ b/purchase.android.ts
@@ -41,12 +41,12 @@ export function init(productIdentifiers: Array<string>): Promise<any> {
         application.android.on(application.AndroidApplication.activityResultEvent, (args: application.AndroidActivityResultEventData) => {
             if (args.requestCode === com.tangrainc.inappbilling.InAppBillingHelper.BUY_INTENT_REQUEST_CODE) {
                 const intent = args.intent as android.content.Intent;
-                const responseCode = intent.getIntExtra("RESPONSE_CODE", 0);
-                const purchaseData = intent.getStringExtra("INAPP_PURCHASE_DATA");
-                const dataSignature = intent.getStringExtra("INAPP_DATA_SIGNATURE");
+                const responseCode = intent && intent.getIntExtra("RESPONSE_CODE", 0);
+                const purchaseData = intent && intent.getStringExtra("INAPP_PURCHASE_DATA");
+                const dataSignature = intent && intent.getStringExtra("INAPP_DATA_SIGNATURE");
                 let tran: Transaction;
                 
-                if (args.resultCode === android.app.Activity.RESULT_OK && responseCode === 0 && !types.isNullOrUndefined(purchaseData)) {
+                if (typeof(responseCode)!=="undefined" && args.resultCode === android.app.Activity.RESULT_OK && responseCode === 0 && !types.isNullOrUndefined(purchaseData)) {
                     const nativeValue = new org.json.JSONObject(purchaseData);
                     nativeValue.put("signature", dataSignature);
                     tran = new Transaction(nativeValue);


### PR DESCRIPTION
Ok. I've uploaded an app to  google play store and in the pre tests , I got an error  : 


```
FATAL EXCEPTION: main
Process: org.royinamir.playwithpinky, PID: 12219
java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=4590, result=0, data=null} to activity {org.royinamir.playwithpinky/com.tns.NativeScriptActivity}: com.tns.NativeScriptException: 
Calling js method onActivityResult failed
TypeError: Cannot read property 'getIntExtra' of null
File: "file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js, line: 1, column: 410904
StackTrace: 
	Frame: function:'', file:'file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js', line: 1, column: 410905
	Frame: function:'e.notify', file:'file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js', line: 1, column: 445959
	Frame: function:'e.onActivityResult', file:'file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js', line: 1, column: 376149
	Frame: function:'r.onActivityResult', file:'file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js', line: 1, column: 1084595
	at android.app.ActivityThread.deliverResults(ActivityThread.java:4750)
	at android.app.ActivityThread.handleSendResult(ActivityThread.java:4793)
	at android.app.ActivityThread.access$1500(ActivityThread.java:218)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1783)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:145)
	at android.app.ActivityThread.main(ActivityThread.java:6934)
	at java.lang.reflect.Method.invoke(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:372)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1404)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1199)
Caused by: com.tns.NativeScriptException: 
Calling js method onActivityResult failed
TypeError: Cannot read property 'getIntExtra' of null
File: "file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js, line: 1, column: 410904
StackTrace: 
	Frame: function:'', file:'file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js', line: 1, column: 410905
	Frame: function:'e.notify', file:'file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js', line: 1, column: 445959
	Frame: function:'e.onActivityResult', file:'file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js', line: 1, column: 376149
	Frame: function:'r.onActivityResult', file:'file:///data/data/org.royinamir.playwithpinky/files/app/vendor.js', line: 1, column: 1084595
	at com.tns.Runtime.callJSMethodNative(Native Method)
	at com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1101)
	at com.tns.Runtime.callJSMethodImpl(Runtime.java:983)
	at com.tns.Runtime.callJSMethod(Runtime.java:970)
	at com.tns.Runtime.callJSMethod(Runtime.java:954)
	at com.tns.Runtime.callJSMethod(Runtime.java:946)
	at com.tns.NativeScriptActivity.onActivityResult(NativeScriptActivity.java:80)
	at android.app.Activity.dispatchActivityResult(Activity.java:6867)
	at android.app.ActivityThread.deliverResults(ActivityThread.java:4746)
	... 10 more
Error reporting crash
java.lang.SecurityException: Calling from not trusted UID!
	at android.os.Parcel.readException(Parcel.java:1546)
	at android.os.Parcel.readException(Parcel.java:1499)
	at android.app.ActivityManagerProxy.handleApplicationCrash(ActivityManagerNative.java:5193)
	at com.android.internal.os.RuntimeInit$UncaughtHandler.uncaughtException(RuntimeInit.java:95)
	at com.tns.NativeScriptUncaughtExceptionHandler.uncaughtException(NativeScriptUncaughtExceptionHandler.java:64)
	at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:693)
	at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:690)
	at android.support.test.runner.MonitoringInstrumentation$3.uncaughtException(MonitoringInstrumentation.java:8)
```

searched who activate this method : 

![image](https://user-images.githubusercontent.com/2842123/41497205-676c7214-7159-11e8-8299-28bf90081de3.png)



Finding the method and the line : 

![image](https://user-images.githubusercontent.com/2842123/41497201-4c4be96a-7159-11e8-8edd-74537bc356ee.png)


led me to the plugin code : 

![image](https://user-images.githubusercontent.com/2842123/41497202-54ea6312-7159-11e8-829d-41c0c983010a.png)


for some reason this : 

`var intent = args.intent;` is null on some callbacks.

