### PR TITLE
Return promise for restorePurchase

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Buys the given product. On Android you can send custom string data that will be 
 * **consumePurchase(string): Promise<number>**  
 Consumes the purchases represented by the given transaction token. If the promise returns `0` the consume was successful. Note that this is needed only for Android. For iOS each purchase is automatically consumed when it is set up as a consumabel product in iTunes. 
 
-* **restorePurchases(): void | Promise<void>**  
-Restores previous purchased items for the current user. On Android, returns a promise for when the purchases have been restored. On iOS, returns undefined.
+* **restorePurchases(): Promise<void>**
+Restores previous purchased items for the current user. On Android, returns a promise for when the purchases have been restored. On iOS, returns a completed promise (as you can use getStoreReceipt to get the receipt instantly anytime).
 
 * **getStoreReceipt(): string**  
 Gets the application's Base64 encoded store receipt for the currently logged in store user. This is useful when checking subscription status under iOS. For Android the function always returns `undefined`.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Buys the given product. On Android you can send custom string data that will be 
 * **consumePurchase(string): Promise<number>**  
 Consumes the purchases represented by the given transaction token. If the promise returns `0` the consume was successful. Note that this is needed only for Android. For iOS each purchase is automatically consumed when it is set up as a consumabel product in iTunes. 
 
-* **restorePurchases(): void**  
-Restores previous purchased items for the current user. 
+* **restorePurchases(): void | Promise<void>**  
+Restores previous purchased items for the current user. On Android, returns a promise for when the purchases have been restored. On iOS, returns undefined.
 
 * **getStoreReceipt(): string**  
 Gets the application's Base64 encoded store receipt for the currently logged in store user. This is useful when checking subscription status under iOS. For Android the function always returns `undefined`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-purchase",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/purchase.android.ts
+++ b/purchase.android.ts
@@ -109,10 +109,10 @@ export function consumePurchase(token: string): Promise<number> {
     });
 }
 
-export function restorePurchases() {
+export function restorePurchases(): Promise<void> {
     return Promise.all([
         futureToPromise(helper.getPurchases(null, "inapp")),
-        futureToPromise(helper.getPurchases(null, "subs")),
+        futureToPromise(helper.getPurchases(null, "subs"))
     ]).then((result: Array<Array<org.json.JSONObject>>) => {
         for (let type = 0; type <= 1; type++) {
             for (const item of result[type]) {

--- a/purchase.android.ts
+++ b/purchase.android.ts
@@ -110,7 +110,7 @@ export function consumePurchase(token: string): Promise<number> {
 }
 
 export function restorePurchases() {
-    Promise.all([
+    return Promise.all([
         futureToPromise(helper.getPurchases(null, "inapp")),
         futureToPromise(helper.getPurchases(null, "subs")),
     ]).then((result: Array<Array<org.json.JSONObject>>) => {

--- a/purchase.d.ts
+++ b/purchase.d.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ***************************************************************************** */
 
-declare module "nativescript-purchase" { 
+declare module "nativescript-purchase" {
     import { Product } from "nativescript-purchase/product";
     import { Transaction } from "nativescript-purchase/transaction";
 
@@ -24,10 +24,10 @@ declare module "nativescript-purchase" {
     export function getProducts(): Promise<Array<Product>>;
     export function buyProduct(product: Product, developerPayload?: string);
     export function consumePurchase(token: string): Promise<number>;
-    export function restorePurchases();
+    export function restorePurchases(): void | Promise<void>;
     export function canMakePayments(): boolean;
     export function getStoreReceipt(): string;
-    
+
     export function on(eventName: string, handler: (data: any) => void);
     export function on(eventName: "transactionUpdated", handler: (data: Transaction) => void);
 

--- a/purchase.d.ts
+++ b/purchase.d.ts
@@ -24,7 +24,7 @@ declare module "nativescript-purchase" {
     export function getProducts(): Promise<Array<Product>>;
     export function buyProduct(product: Product, developerPayload?: string);
     export function consumePurchase(token: string): Promise<number>;
-    export function restorePurchases(): void | Promise<void>;
+    export function restorePurchases(): Promise<void>;
     export function canMakePayments(): boolean;
     export function getStoreReceipt(): string;
 

--- a/purchase.ios.ts
+++ b/purchase.ios.ts
@@ -64,8 +64,9 @@ export function consumePurchase(token: string): Promise<number> {
     });
 }
 
-export function restorePurchases() {
+export function restorePurchases(): Promise<void> {
     SKPaymentQueue.defaultQueue().restoreCompletedTransactions();
+    return Promise.resolve();
 }
 
 export function canMakePayments(): boolean {


### PR DESCRIPTION
We ran into a scenario where we wanted to know if restore purchases returned no purchases at all on Android. This doesn't get expressed through Transactions, so this pull request makes restorePurchases return its promise on Android, so that the caller can know when it's done. It still returns nothing on iOS, but you can use getStoreReceipt to do the same thing.