### PR TITLE
Fix null check in iOS transactions

### DIFF
--- a/transaction/transaction.ios.ts
+++ b/transaction/transaction.ios.ts
@@ -22,7 +22,7 @@ export class Transaction extends TransactionBase {
     constructor(nativeValue: SKPaymentTransaction) {
         super(nativeValue);
 
-        if (nativeValue.transactionState === null) {
+        if (nativeValue !== null) {
             switch (nativeValue.transactionState) {
                 case SKPaymentTransactionState.Deferred:
                     this.transactionState = TransactionState.Deferred;


### PR DESCRIPTION
The iOS transaction class has its null check backwards. It only attempts to use transactionState if it _is_ null, rather than if the transaction _is not_ null. Related to #58 