### PR TITLE
feat(ios): Expose finishTransaction method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Restores previous purchased items for the current user. On Android, returns a pr
 * **getStoreReceipt(): string**  
 Gets the application's Base64 encoded store receipt for the currently logged in store user. This is useful when checking subscription status under iOS. For Android the function always returns `undefined`.
 
+* **finishTransaction(): Promise<void>**
+Finishes the transaction that is currently being processed. For iOS, this will finish the transaction and remove it from the queue. On Android, returns a promise that resolves immediately.
+
 ### Events
 * **transactionUpdated**  
 Triggered a buy/restore transaction changes its state. You receive a `Transaction` object where you can check the status and other properties  *(see below)* of the transaction. 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Restores previous purchased items for the current user. On Android, returns a pr
 * **getStoreReceipt(): string**  
 Gets the application's Base64 encoded store receipt for the currently logged in store user. This is useful when checking subscription status under iOS. For Android the function always returns `undefined`.
 
-* **finishTransaction(): Promise<void>**
+* **finishTransaction(Transaction): Promise<void>**
 Finishes the transaction that is currently being processed. For iOS, this will finish the transaction and remove it from the queue. On Android, returns a promise that resolves immediately.
 
 ### Events

--- a/purchase-common.ts
+++ b/purchase-common.ts
@@ -44,12 +44,16 @@ export function off(eventName: string, handler?: (data: any) => void) {
         return;
     }
 
-    let index = observers[eventName].indexOf(handler); 
+    let index = observers[eventName].indexOf(handler);
     if (index !== -1) {
         observers[eventName].splice(index, 1);
-    }    
+    }
 }
 
 export function getStoreReceipt(): string {
     return undefined;
+}
+
+export function finishTransaction(): Promise<void> {
+    return Promise.resolve();
 }

--- a/purchase.ios.ts
+++ b/purchase.ios.ts
@@ -84,6 +84,16 @@ export function getStoreReceipt(): string {
     }
 }
 
+export function finishTransaction(transaction: SKPaymentTransaction): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        if (!transaction) {
+            return reject("No transaction provided to finish");
+        }
+        SKPaymentQueue.defaultQueue().finishTransaction(transaction);
+        resolve();
+    });
+}
+
 @ObjCClass(SKProductsRequestDelegate)
 class SKProductRequestDelegateImpl extends NSObject implements SKProductsRequestDelegate {
     private _resolve: Function;

--- a/purchase.ios.ts
+++ b/purchase.ios.ts
@@ -84,12 +84,12 @@ export function getStoreReceipt(): string {
     }
 }
 
-export function finishTransaction(transaction: SKPaymentTransaction): Promise<void> {
+export function finishTransaction(transaction: Transaction): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         if (!transaction) {
             return reject("No transaction provided to finish");
         }
-        SKPaymentQueue.defaultQueue().finishTransaction(transaction);
+        SKPaymentQueue.defaultQueue().finishTransaction(transaction.nativeValue);
         resolve();
     });
 }


### PR DESCRIPTION
StoreKit calls your observer’s paymentQueue(_:updatedTransactions:) method every time your app launches or resumes from background to tell you about transactions in the queue. Add the ability to finish transactions outside of the purchasing flow.